### PR TITLE
Create VPC with subnets and NAT gateways

### DIFF
--- a/terraform/layers/base/providers.tf
+++ b/terraform/layers/base/providers.tf
@@ -9,6 +9,8 @@ terraform {
 }
 
 provider "aws" {
+  region = "eu-west-2"
+
   default_tags {
     tags = {
       Environment = var.environment

--- a/terraform/layers/base/variables.tf
+++ b/terraform/layers/base/variables.tf
@@ -5,7 +5,7 @@ variable "project" {
 }
 
 variable "environment" {
-  description = "The environement of the resource"
+  description = "The environment of the resource"
   type        = string
   default     = "Dev"
 }

--- a/terraform/layers/base/variables.tf
+++ b/terraform/layers/base/variables.tf
@@ -10,3 +10,8 @@ variable "environment" {
   default     = "Dev"
 }
 
+variable "cidr" {
+  description = "CIDR of the VPC to be created"
+  type        = string
+  default     = "10.0.0.0/16"
+}

--- a/terraform/layers/base/vpc.tf
+++ b/terraform/layers/base/vpc.tf
@@ -4,15 +4,16 @@ data "aws_availability_zones" "available" {
 }
 
 locals {
-  azs  = data.aws_availability_zones.available.names
-  cidr = "10.0.0.0/16"
+  azs             = data.aws_availability_zones.available.names
+  cidr            = var.cidr
+  resource_prefix = "${var.project}-${var.environment}"
 }
 
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
 
-  name = "dev-vpc"
+  name = "${local.resource_prefix}-vpc"
   cidr = local.cidr
 
 

--- a/terraform/layers/base/vpc.tf
+++ b/terraform/layers/base/vpc.tf
@@ -1,0 +1,29 @@
+// Get names of the available AZs
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  azs  = data.aws_availability_zones.available.names
+  cidr = "10.0.0.0/16"
+}
+
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "dev-vpc"
+  cidr = local.cidr
+
+
+  azs             = local.azs
+  private_subnets = [for k, _ in local.azs : cidrsubnet(local.cidr, 3, k)]
+  public_subnets  = [for k, _ in local.azs : cidrsubnet(local.cidr, 3, k + 4)]
+
+
+  enable_nat_gateway = true
+  single_nat_gateway = var.environment == "Dev" ? true : false
+
+
+
+}


### PR DESCRIPTION
Creates VPC with a public and private subnet for each AZ, with IPs equally distributed. If the environment variable is Dev, only one NAT gateway is created, for all other environments a NAT gateway per subnet is created.  