### PR TITLE
Create IAM role and policy for EC2 to access S3

### DIFF
--- a/terraform/layers/app/iam.tf
+++ b/terraform/layers/app/iam.tf
@@ -7,9 +7,13 @@ output "s3_name" {
   value = module.base.s3_webfiles_arn
 }
 
+locals {
+  resource_prefix = "${var.project}-${var.environment}"
+}
+
 // Create IAM role
 resource "aws_iam_role" "s3_webfiles_access" {
-  name = "s3_webfiles_access"
+  name = "${local.resource_prefix}_s3_webfiles_access"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -28,7 +32,7 @@ resource "aws_iam_role" "s3_webfiles_access" {
 
 // Create IAM policy allowing access to S3 bucket 
 resource "aws_iam_policy" "s3_access_policy" {
-  name        = "S3AccessPolicy"
+  name        = "${local.resource_prefix}_s3_access_policy"
   description = "Allows EC2 instance to access web files S3 bucket"
 
   policy = jsonencode({

--- a/terraform/layers/app/iam.tf
+++ b/terraform/layers/app/iam.tf
@@ -1,5 +1,10 @@
-data "aws_s3" "s3_webfiles_bucket" {
+// Find base module
+module "base" {
+  source = "../base"
+}
 
+output "s3_name" {
+  value = module.base.s3_webfiles_arn
 }
 
 // Create IAM role
@@ -36,8 +41,8 @@ resource "aws_iam_policy" "s3_access_policy" {
           "s3:ListBucket"
         ]
         Resource = [
-          "arn:aws:s3:::your-bucket-name",
-          "arn:aws:s3:::your-bucket-name/*"
+          "${module.base.s3_webfiles_arn}",
+          "${module.base.s3_webfiles_arn}/*"
         ]
       }
     ]

--- a/terraform/layers/app/iam.tf
+++ b/terraform/layers/app/iam.tf
@@ -1,0 +1,45 @@
+data "aws_s3" "s3_webfiles_bucket" {
+
+}
+
+// Create IAM role
+resource "aws_iam_role" "s3_webfiles_access" {
+  name = "s3_webfiles_access"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+// Create IAM policy allowing access to S3 bucket 
+resource "aws_iam_policy" "s3_access_policy" {
+  name        = "S3AccessPolicy"
+  description = "Allows EC2 instance to access web files S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::your-bucket-name",
+          "arn:aws:s3:::your-bucket-name/*"
+        ]
+      }
+    ]
+  })
+}

--- a/terraform/layers/app/variables.tf
+++ b/terraform/layers/app/variables.tf
@@ -1,7 +1,7 @@
 variable "project" {
   description = "The name of the project"
   type        = string
-  default     = "Grad-lab-1"
+  default     = "grad-lab-1"
 }
 
 variable "environment" {

--- a/terraform/layers/base/vpc.tf
+++ b/terraform/layers/base/vpc.tf
@@ -4,9 +4,8 @@ data "aws_availability_zones" "available" {
 }
 
 locals {
-  azs             = data.aws_availability_zones.available.names
-  cidr            = var.cidr
-  resource_prefix = "${var.project}-${var.environment}"
+  azs  = data.aws_availability_zones.available.names
+  cidr = var.cidr
 }
 
 


### PR DESCRIPTION
Allows EC2 instances to access the S3 web files bucket only, and copy files back to EC2.
At present this PR uses the output ARN from the base module to locate the bucket, in future this should be changed to use a data block, which I am planning to come back to once more of the base functionality is implemented. 